### PR TITLE
Prefix SVG image src attribute with Jekyll baseurl

### DIFF
--- a/lib/jekyll-plantuml.rb
+++ b/lib/jekyll-plantuml.rb
@@ -52,7 +52,7 @@ module Jekyll
           puts "File #{svg} created (#{File.size(svg)} bytes)"
         end
       end
-      "<p><img src='/uml/#{name}.svg' #{@html}
+      "<p><img src='#{site.baseurl}/uml/#{name}.svg' #{@html}
         alt='PlantUML SVG diagram' class='plantuml'/></p>"
     end
   end


### PR DESCRIPTION
This allows the use of a non-empty `baseurl` for included PlantUML diagrams.