### PR TITLE
Change the output tag from img to object

### DIFF
--- a/lib/jekyll-plantuml.rb
+++ b/lib/jekyll-plantuml.rb
@@ -52,8 +52,8 @@ module Jekyll
           puts "File #{svg} created (#{File.size(svg)} bytes)"
         end
       end
-      "<p><img src='#{site.baseurl}/uml/#{name}.svg' #{@html}
-        alt='PlantUML SVG diagram' class='plantuml'/></p>"
+      "<p><object data='#{site.baseurl}/uml/#{name}.svg' #{@html}
+        type='image/svg+xml'></object></p>"
     end
   end
 end

--- a/lib/jekyll-plantuml.rb
+++ b/lib/jekyll-plantuml.rb
@@ -52,8 +52,7 @@ module Jekyll
           puts "File #{svg} created (#{File.size(svg)} bytes)"
         end
       end
-      "<p><object data='#{site.baseurl}/uml/#{name}.svg' #{@html}
-        type='image/svg+xml'></object></p>"
+      "<p><object data='#{site.baseurl}/uml/#{name}.svg' type='image/svg+xml' #{@html}></object></p>"
     end
   end
 end


### PR DESCRIPTION
With this change we can use hyperlinks capabilty of the svg  and plantuml
an example :

`
{% plantuml %}
actor Bob
actor "[[ {{ site.url }}{% link alice.md %} Alice]]" as Alice
Bob -> Alice [[http://plantuml.com/start]] : hello
note left [[http://plantuml.com/start]]
  a note with a link
end note
{% endplantuml %}
`

With img tag, the hyperlink is not clickable 
```
<html>
    <body>
        <p>
            <object data="8b847b7a3e19b67312cebb77a7e1eeae.svg" type="image/svg+xml"></object>
            <img src="8b847b7a3e19b67312cebb77a7e1eeae.svg" alt="PLant UML SVG DIAg" class="plantuml"/>
        </p>

    </body>
</html>
```


Many thanks for your contribution, we truly appreciate it. We will appreciate it even more, if you make sure that you can say "YES" to each point in this short checklist:

  - You made a small amount of changes (less than 100 lines, less than 10 files)
  - You made changes related to only one bug (create separate PRs for separate problems)
  - You are ready to defend your changes (there will be a code review)
  - You don't touch what you don't understand
  - You ran the build locally and it passed

This article will help you understand what we are looking for: http://www.yegor256.com/2015/02/09/serious-code-reviewer.html

Thank you for your contribution!
