### PR TITLE
Raise an error when there is a problem

### DIFF
--- a/lib/jekyll-plantuml.rb
+++ b/lib/jekyll-plantuml.rb
@@ -45,7 +45,7 @@ module Jekyll
             f.write(super)
             f.write("\n@enduml")
           }
-          system("plantuml -tsvg #{uml}")
+          system("plantuml -tsvg #{uml}") or raise "PlantUML error: #{super}"
           site.static_files << Jekyll::StaticFile.new(
             site, site.source, 'uml', "#{name}.svg"
           )


### PR DESCRIPTION
Currently, if there is an error during the PlantUML generation process (either by missing the plantuml jar or error with the diagram) the site builds just fine but there will be an error image. This PR makes it fail-fast so that if there is an error the site won't build.