### PR TITLE
Add plantuml class

### DIFF
--- a/lib/jekyll-plantuml.rb
+++ b/lib/jekyll-plantuml.rb
@@ -52,7 +52,7 @@ module Jekyll
           puts "File #{svg} created (#{File.size(svg)} bytes)"
         end
       end
-      "<p><object data='#{site.baseurl}/uml/#{name}.svg' type='image/svg+xml' #{@html}></object></p>"
+      "<p><object data='#{site.baseurl}/uml/#{name}.svg' type='image/svg+xml' #{@html} class='plantuml'></object></p>"
     end
   end
 end


### PR DESCRIPTION
In the current version ([1.3.3](https://github.com/yegor256/jekyll-plantuml/blob/11015730e2328f653bff87808cf2b64293aa4766/lib/jekyll-plantuml.rb#L56)) a ```plantuml``` class is added to the ```img```. This PR adds that class back.