### PR TITLE
#1 raise a clear error when plantuml binary is missing

### DIFF
--- a/lib/jekyll-plantuml-file.rb
+++ b/lib/jekyll-plantuml-file.rb
@@ -7,6 +7,7 @@ require 'jekyll'
 require 'liquid'
 require 'digest'
 require 'fileutils'
+require_relative 'jekyll-plantuml-support'
 
 # Jekyll main module.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -33,9 +34,7 @@ class Jekyll::PlantumlFile < Liquid::Block
         uml = File.join(site.source, "uml/#{name}.uml")
         FileUtils.mkdir_p(File.dirname(uml))
         IO.copy_stream(full_file_name, uml)
-        unless system("plantuml -tsvg #{uml} 2>&1")
-          raise "PlantUML failed to compile the following snippet (see logs above):\n#{body}\n"
-        end
+        Jekyll::PlantumlSupport.run_plantuml(uml, body)
         site.static_files << Jekyll::StaticFile.new(
           site, site.source, 'uml', "#{name}.svg"
         )

--- a/lib/jekyll-plantuml-support.rb
+++ b/lib/jekyll-plantuml-support.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2014-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'jekyll'
+
+# Helpers for the PlantUML Jekyll plugin.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2014-2026 Yegor Bugayenko
+# License:: MIT
+module Jekyll::PlantumlSupport
+  module_function
+
+  def plantuml_executable?
+    paths = (ENV['PATH'] || '').split(File::PATH_SEPARATOR)
+    exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(File::PATH_SEPARATOR) : ['']
+    paths.any? do |p|
+      exts.any? do |ext|
+        candidate = File.join(p, "plantuml#{ext}")
+        File.file?(candidate) && File.executable?(candidate)
+      end
+    end
+  end
+
+  def run_plantuml(uml, body)
+    unless plantuml_executable?
+      raise 'PlantUML executable was not found on PATH; please install PlantUML ' \
+            '(see https://plantuml.com/starting) and make sure it can be invoked ' \
+            "as 'plantuml' from the command line"
+    end
+    return if system("plantuml -tsvg #{uml} 2>&1")
+    raise "PlantUML failed to compile the following snippet (see logs above):\n#{body}\n"
+  end
+end

--- a/lib/jekyll-plantuml.rb
+++ b/lib/jekyll-plantuml.rb
@@ -31,9 +31,7 @@ class Jekyll::PlantumlBlock < Liquid::Block
       else
         FileUtils.mkdir_p(File.dirname(uml))
         File.write(uml, ["@startuml\n", body, "\n@enduml"].join)
-        unless system("plantuml -tsvg #{uml} 2>&1")
-          raise "PlantUML failed to compile the following snippet (see logs above):\n#{body}\n"
-        end
+        Jekyll::PlantumlSupport.run_plantuml(uml, body)
         site.static_files << Jekyll::StaticFile.new(
           site, site.source, 'uml', "#{name}.svg"
         )

--- a/test/test_plantuml-file.rb
+++ b/test/test_plantuml-file.rb
@@ -36,4 +36,30 @@ class PlantumlFileTest < Minitest::Test
       assert(output.start_with?('<p><object'))
     end
   end
+
+  def test_clear_error_when_plantuml_not_installed
+    schema_file = File.join(Dir.getwd, 'test/schema.puml')
+    Dir.mktmpdir 'test' do |dir|
+      template = Liquid::Template.parse('{% plantuml_file %}schema.puml{% endplantuml_file %}')
+      source_dir = File.join(dir, 'source')
+      target_file = File.join(source_dir, 'schema.puml')
+      FileUtils.mkdir_p(source_dir)
+      FileUtils.cp(schema_file, target_file)
+      config = {
+        'destination' => File.join(dir, 'dest'),
+        'source' => source_dir
+      }
+      context = Liquid::Context.new({}, {}, { site: Jekyll::Site.new(Jekyll.configuration(config)) })
+      block = template.root.nodelist.first
+      original_path = ENV.fetch('PATH', nil)
+      begin
+        ENV['PATH'] = File.join(dir, 'no-such-dir')
+        error = assert_raises(RuntimeError) { block.render(context) }
+        assert_match(/plantuml/i, error.message)
+        assert_match(/not (?:found|installed|on PATH|in PATH|available)/i, error.message)
+      ensure
+        ENV['PATH'] = original_path
+      end
+    end
+  end
 end

--- a/test/test_plantuml.rb
+++ b/test/test_plantuml.rb
@@ -26,4 +26,25 @@ class PlantumlBlockTest < Minitest::Test
       assert(output.start_with?('<p><object'))
     end
   end
+
+  def test_clear_error_when_plantuml_not_installed
+    Dir.mktmpdir 'test' do |dir|
+      template = Liquid::Template.parse('{% plantuml %}[A] -> [B]{% endplantuml %}')
+      config = {
+        'destination' => File.join(dir, 'dest'),
+        'source' => File.join(dir, 'source')
+      }
+      context = Liquid::Context.new({}, {}, { site: Jekyll::Site.new(Jekyll.configuration(config)) })
+      block = template.root.nodelist.first
+      original_path = ENV.fetch('PATH', nil)
+      begin
+        ENV['PATH'] = File.join(dir, 'no-such-dir')
+        error = assert_raises(RuntimeError) { block.render(context) }
+        assert_match(/plantuml/i, error.message)
+        assert_match(/not (?:found|installed|on PATH|in PATH|available)/i, error.message)
+      ensure
+        ENV['PATH'] = original_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
@yegor256

This PR closes #1 — the long-standing issue (filed July 2014 by @carlosmiranda) where the plugin would silently fail with a confusing message when PlantUML was not installed on the build machine.

## What changed

When  is not on , the plugin previously raised the misleading error:

> PlantUML failed to compile the following snippet (see logs above)

This sent users hunting for nonexistent UML syntax errors when the real problem was a missing executable. The plugin now pre-checks whether  is reachable on  and, if not, raises a message that names the missing executable and points to the install instructions:

> PlantUML executable was not found on PATH; please install PlantUML (see https://plantuml.com/starting) and make sure it can be invoked as ''plantuml'' from the command line

## Why a pre-check (not just inspecting  return value)?

The existing  call routes through  because of the  redirect, so a missing executable surfaces as  (the shell exits non-zero), not as . Distinguishing  vs  is therefore not enough — we need to look up the binary on  ourselves before invoking it.

## Implementation

* New  module in  exposes:
  -  — walks  (and  on Windows) looking for an executable file named .
  -  — raises the clear "executable not found on PATH" error first, otherwise runs the existing  command and raises the previous "failed to compile" error on non-zero exit.
*  and  now delegate to , removing the duplicated  logic.

## Tests

Two new tests, one per block class (), set  to a non-existent directory and assert the raised message mentions  and "not found / not on PATH". The existing happy-path tests are unchanged and still pass.

## Local verification

*  — 4 tests, 12 assertions, 0 failures, 0 errors
*  — 12 files inspected, no offenses
* # SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
* Missing licenses: 0
* Unused licenses: 0
* Used licenses: 0
* Read errors: 0
* Invalid SPDX License Expressions: 0
* Files with copyright information: 0 / 0
* Files with license information: 0 / 0

Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-) — compliant with REUSE 3.3
*  — clean

All 9 CI checks are green: rake, rubocop, copyrights, reuse, typos, markdown-lint, actionlint, yamllint, xcop, pdd. Ready for your review.