### PR TITLE
#96: document Jekyll plugin loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,21 @@ create a plugin file within your Jekyll project's `_plugins` directory:
 require "jekyll-plantuml"
 ```
 
-We highly recommend using Bundler. If you're using it, add this line
-to your `Gemfile`:
+We highly recommend using Bundler. With Jekyll 3 and newer, put the gem
+in the `:jekyll_plugins` group so Jekyll loads the tag:
 
 ```ruby
-gem "jekyll-plantuml"
+group :jekyll_plugins do
+  gem "jekyll-plantuml"
+end
+```
+
+If you keep the gem outside that group, add it to your `_config.yml`
+plugins list instead:
+
+```yaml
+plugins:
+  - jekyll-plantuml
 ```
 
 The plugin is compatible with [Jekyll 3.9.3][jekyll-3]


### PR DESCRIPTION
Fixes #96.

## Summary
- Documents the Jekyll 3/4 Bundler plugin-loading form with `group :jekyll_plugins`.
- Adds the `_config.yml` `plugins` fallback for Gemfiles that keep the gem outside that group.

## Validation
- Reproduced the reported failure with a temporary Jekyll 4.4.1 site using only `gem "jekyll-plantuml", path: ...` in the Gemfile and no `_config.yml` plugin entry: `bundle exec jekyll build --trace` exits with `Unknown tag 'plantuml'`.
- Verified the documented Bundler form with no `_config.yml` plugin entry: `group :jekyll_plugins do ... end` loads the tag and proceeds to the local `PlantUML executable was not found on PATH` error instead of `Unknown tag`.
- `npx --yes markdownlint-cli2 README.md` -> 0 errors.
- `PATH="$fake:$PATH" mise exec ruby@3.3.11 -- bundle exec rake test` with a local fake `plantuml` executable -> 4 tests, 12 assertions, 0 failures, 0 errors.
- `git diff --check HEAD~1..HEAD` -> passed.
- `git diff HEAD~1..HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

## Limitation
- Full integration with a real PlantUML binary was not run on this host because `plantuml` is not installed locally.
